### PR TITLE
Randomiser Update

### DIFF
--- a/Pokemon Tabletop Adventure/Data Models/WBPokémon.swift
+++ b/Pokemon Tabletop Adventure/Data Models/WBPokémon.swift
@@ -12,7 +12,7 @@ struct Pokédex: Codable {
     let pokémon: [Pokémon]
 }
 
-struct Pokémon: Codable {
+struct Pokémon: Codable, Equatable {
     let dexNumber: Int
     let name: String
     let stats: StatArray
@@ -20,6 +20,7 @@ struct Pokémon: Codable {
     let abilities: PokeAbilities
     let evolution: [String: Int]
     let biology: PokeBiology
+    
     func basicDescription() -> String {
         return """
         Pokémon: \(name)
@@ -32,6 +33,12 @@ struct Pokémon: Codable {
             SPD: \(stats.SPD)
         """
     }
+    
+    static func ==(lhs: Pokémon, rhs: Pokémon) -> Bool {
+        let areEqual = lhs.dexNumber == rhs.dexNumber
+        return areEqual
+    }
+    
     private enum CodingKeys: String, CodingKey {
         case dexNumber = "id"
         case name
@@ -41,12 +48,6 @@ struct Pokémon: Codable {
         case evolution
         case biology
     }
-}
-
-extension Pokémon: Equatable {}
-func ==(lhs: Pokémon, rhs: Pokémon) -> Bool {
-    let areEqual = lhs.dexNumber == rhs.dexNumber
-    return areEqual
 }
 
 struct StatArray: Codable {

--- a/Pokemon Tabletop Adventure/View Controllers/WBRandomPokémonViewController.swift
+++ b/Pokemon Tabletop Adventure/View Controllers/WBRandomPokémonViewController.swift
@@ -32,7 +32,7 @@ class WBRandomPokémonViewController: WBBaseViewController {
     }
     
     override func viewWillAppear(_ animated: Bool) {
-        showRandomPokémon()
+        descriptionLabel.text = randomViewModel.describeCurrentPokémon
     }
     
     override func setupViews() {
@@ -62,7 +62,5 @@ class WBRandomPokémonViewController: WBBaseViewController {
     @objc private func showRandomPokémon() {
         let chosenPokémon: Pokémon = randomViewModel.getRandomPokémon()
         descriptionLabel.text = chosenPokémon.basicDescription()
-        
-        print("Choosing pokémon #\(chosenPokémon.dexNumber) - \(chosenPokémon.name)")
     }
 }

--- a/Pokemon Tabletop Adventure/View Controllers/WBTabBarController.swift
+++ b/Pokemon Tabletop Adventure/View Controllers/WBTabBarController.swift
@@ -10,15 +10,10 @@ import UIKit
 
 class WBTabBarController: UITabBarController {
 
-//    let randomiser: WBRandomPokémonViewController
-    
     convenience init() {
         let randomiser = WBRandomPokémonViewController(with: WBRandomPokémonViewModel())
-        // TODO: Fix Icon size being WAAAAY too large
-        let unselected = UIImage(named: "tabbar-items/pokeball-unselected")
-        let selected = UIImage(named: "tabbar-items/pokeball-selected")
-        
-        let tabBarItem = UITabBarItem(title: nil, image: unselected, selectedImage: selected)
+        let icon = UIImage(named: "tabbar-items/pokeball-unselected")
+        let tabBarItem = UITabBarItem(title: "Randomiser", image: icon, selectedImage: icon)
         randomiser.tabBarItem = tabBarItem
         
         let blankVC = UIViewController()

--- a/Pokemon Tabletop Adventure/View Models/WBRandomPokémonViewModel.swift
+++ b/Pokemon Tabletop Adventure/View Models/WBRandomPokémonViewModel.swift
@@ -12,12 +12,18 @@ class WBRandomPokémonViewModel: WBBaseViewModel {
     private var pokémon = [Pokémon]()
     private var current: Pokémon?
     
+    var describeCurrentPokémon: String {
+        let pokémon = current ?? getRandomPokémon()
+        return pokémon.basicDescription()
+    }
+    
     override init() {
         pokémon = WBJSON.pokémon()
     }
     
     func getRandomPokémon() -> Pokémon {
         let random = pokémon.random(avoiding: current)
+        print("Choosing pokémon #\(random.dexNumber) - \(random.name)")
         current = random
         return random
     }


### PR DESCRIPTION
### Fixes #3: Randomiser shows new pokémon too often

Randomiser
* Added description of current pokémon
  * View controller fetches this description on viewWillAppear, keeping the display static
  * If no pokémon is set, fetches a random pokémon

Pokémon
* Cleaned up structs
* Added Equatable to main body, with static equality checker

Tab Bar
* Got rid of the use of the selected
* Uses old unselected icon for both states
* Added title to randomiser