### PR TITLE
Adding a Root Coordinator

### DIFF
--- a/Pokemon Tabletop Adventure.xcodeproj/project.pbxproj
+++ b/Pokemon Tabletop Adventure.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		73F59BA42672ACF100A77A21 /* Coordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73F59BA32672ACF100A77A21 /* Coordinator.swift */; };
 		73F59BAE2672B18E00A77A21 /* RootCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73F59BAD2672B18E00A77A21 /* RootCoordinator.swift */; };
+		73F59BB62672B4E200A77A21 /* ActionDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73F59BB52672B4E200A77A21 /* ActionDelegate.swift */; };
+		73F59BBC2672B73B00A77A21 /* PreliminaryLoadingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73F59BBB2672B73B00A77A21 /* PreliminaryLoadingViewModel.swift */; };
 		DC3BD48F20A3591D0043B49C /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC3BD48E20A3591D0043B49C /* AppDelegate.swift */; };
 		DC3BD49720A3591D0043B49C /* Pokemon_Tabletop_Adventure.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = DC3BD49520A3591D0043B49C /* Pokemon_Tabletop_Adventure.xcdatamodeld */; };
 		DC3BD49920A3591F0043B49C /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = DC3BD49820A3591F0043B49C /* Assets.xcassets */; };
@@ -57,6 +59,8 @@
 /* Begin PBXFileReference section */
 		73F59BA32672ACF100A77A21 /* Coordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coordinator.swift; sourceTree = "<group>"; };
 		73F59BAD2672B18E00A77A21 /* RootCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootCoordinator.swift; sourceTree = "<group>"; };
+		73F59BB52672B4E200A77A21 /* ActionDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionDelegate.swift; sourceTree = "<group>"; };
+		73F59BBB2672B73B00A77A21 /* PreliminaryLoadingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreliminaryLoadingViewModel.swift; sourceTree = "<group>"; };
 		DC3BD48B20A3591D0043B49C /* PTA Companion.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "PTA Companion.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		DC3BD48E20A3591D0043B49C /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		DC3BD49620A3591D0043B49C /* Pokemon_Tabletop_Adventure.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Pokemon_Tabletop_Adventure.xcdatamodel; sourceTree = "<group>"; };
@@ -207,6 +211,7 @@
 		DCB170A720F2B48600BAA64D /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
+				73F59BB52672B4E200A77A21 /* ActionDelegate.swift */,
 				DC3BD48E20A3591D0043B49C /* AppDelegate.swift */,
 				DCB170A820F2B4A400BAA64D /* JSON.swift */,
 				DCB170B220F3529700BAA64D /* Extensions.swift */,
@@ -219,6 +224,7 @@
 			children = (
 				DCB170B020F34EFD00BAA64D /* BaseViewModel.swift */,
 				DC6A20D6211E02E30024F77D /* PokedexViewModel.swift */,
+				73F59BBB2672B73B00A77A21 /* PreliminaryLoadingViewModel.swift */,
 				DCB170AC20F34E5500BAA64D /* RandomPokemonViewModel.swift */,
 				DCF15BD5211E35710003DA31 /* TableManager.swift */,
 				DC9E1DC620FFCE11006D6B97 /* TrainerViewModel.swift */,
@@ -436,9 +442,11 @@
 				DCB170B120F34EFD00BAA64D /* BaseViewModel.swift in Sources */,
 				DC6A20D5211E02390024F77D /* PokedexViewController.swift in Sources */,
 				DCB170B320F3529700BAA64D /* Extensions.swift in Sources */,
+				73F59BB62672B4E200A77A21 /* ActionDelegate.swift in Sources */,
 				DCB170AF20F34E7F00BAA64D /* RandomPokemonViewController.swift in Sources */,
 				FFF91FE22252577E0064BEF6 /* CreditAttributionTableViewCell.swift in Sources */,
 				DCB170AD20F34E5500BAA64D /* RandomPokemonViewModel.swift in Sources */,
+				73F59BBC2672B73B00A77A21 /* PreliminaryLoadingViewModel.swift in Sources */,
 				FF56E241224B9A0F00E14330 /* RootViewController.swift in Sources */,
 				FF56E243224B9A2500E14330 /* PreliminaryLoadingViewController.swift in Sources */,
 				DC9E1DC520FFBDB2006D6B97 /* TrainerViewController.swift in Sources */,

--- a/Pokemon Tabletop Adventure.xcodeproj/project.pbxproj
+++ b/Pokemon Tabletop Adventure.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		73F59BA42672ACF100A77A21 /* Coordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73F59BA32672ACF100A77A21 /* Coordinator.swift */; };
+		73F59BAE2672B18E00A77A21 /* RootCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73F59BAD2672B18E00A77A21 /* RootCoordinator.swift */; };
 		DC3BD48F20A3591D0043B49C /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC3BD48E20A3591D0043B49C /* AppDelegate.swift */; };
 		DC3BD49720A3591D0043B49C /* Pokemon_Tabletop_Adventure.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = DC3BD49520A3591D0043B49C /* Pokemon_Tabletop_Adventure.xcdatamodeld */; };
 		DC3BD49920A3591F0043B49C /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = DC3BD49820A3591F0043B49C /* Assets.xcassets */; };
@@ -53,6 +55,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		73F59BA32672ACF100A77A21 /* Coordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coordinator.swift; sourceTree = "<group>"; };
+		73F59BAD2672B18E00A77A21 /* RootCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootCoordinator.swift; sourceTree = "<group>"; };
 		DC3BD48B20A3591D0043B49C /* PTA Companion.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "PTA Companion.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		DC3BD48E20A3591D0043B49C /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		DC3BD49620A3591D0043B49C /* Pokemon_Tabletop_Adventure.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Pokemon_Tabletop_Adventure.xcdatamodel; sourceTree = "<group>"; };
@@ -109,6 +113,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		73F59BA22672ACD300A77A21 /* Coordinators */ = {
+			isa = PBXGroup;
+			children = (
+				73F59BA32672ACF100A77A21 /* Coordinator.swift */,
+				73F59BAD2672B18E00A77A21 /* RootCoordinator.swift */,
+			);
+			path = Coordinators;
+			sourceTree = "<group>";
+		};
 		DC3BD48220A3591D0043B49C = {
 			isa = PBXGroup;
 			children = (
@@ -130,8 +143,9 @@
 		DC3BD48D20A3591D0043B49C /* Pokemon Tabletop Adventure */ = {
 			isa = PBXGroup;
 			children = (
-				DCB170A720F2B48600BAA64D /* Utilities */,
+				73F59BA22672ACD300A77A21 /* Coordinators */,
 				DCB170A420F2AF7000BAA64D /* Data Models */,
+				DCB170A720F2B48600BAA64D /* Utilities */,
 				DCDA770820EF5B6800BC0D55 /* View Controllers */,
 				DCB170AA20F34E1600BAA64D /* View Models */,
 				FFF91FDF2252572F0064BEF6 /* Views */,
@@ -430,12 +444,14 @@
 				DC9E1DC520FFBDB2006D6B97 /* TrainerViewController.swift in Sources */,
 				DC9E1DC720FFCE11006D6B97 /* TrainerViewModel.swift in Sources */,
 				DC3BD49720A3591D0043B49C /* Pokemon_Tabletop_Adventure.xcdatamodeld in Sources */,
+				73F59BA42672ACF100A77A21 /* Coordinator.swift in Sources */,
 				DCF15BD6211E35710003DA31 /* TableManager.swift in Sources */,
 				FFF91FDE22524B800064BEF6 /* AboutViewController.swift in Sources */,
 				DCB170A920F2B4A400BAA64D /* JSON.swift in Sources */,
 				DCB170A620F2AF8600BAA64D /* Pokemon.swift in Sources */,
 				DCDA770A20EF5B9000BC0D55 /* BaseViewController.swift in Sources */,
 				DC60F27620F3C33E00DF1C98 /* TabBarController.swift in Sources */,
+				73F59BAE2672B18E00A77A21 /* RootCoordinator.swift in Sources */,
 				DC3BD48F20A3591D0043B49C /* AppDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Pokemon Tabletop Adventure/Coordinators/Coordinator.swift
+++ b/Pokemon Tabletop Adventure/Coordinators/Coordinator.swift
@@ -14,3 +14,13 @@ protocol Coordinator {
     
     func start()
 }
+
+extension Coordinator {
+    func launch(_ viewController: UIViewController) {
+        if router.viewControllers.contains(viewController) {
+            router.popToViewController(viewController, animated: true)
+        } else {
+            router.pushViewController(viewController, animated: true)
+        }
+    }
+}

--- a/Pokemon Tabletop Adventure/Coordinators/Coordinator.swift
+++ b/Pokemon Tabletop Adventure/Coordinators/Coordinator.swift
@@ -1,0 +1,16 @@
+//
+//  Coordinator.swift
+//  PTA Companion
+//
+//  Created by Ian Merryweather on 10/06/2021.
+//  Copyright © 2021 Undersea Love. All rights reserved.
+//
+
+import UIKit
+
+protocol Coordinator {
+    var childCoordinators: [Coordinator] { get }
+    var router: UINavigationController { get }
+    
+    func start()
+}

--- a/Pokemon Tabletop Adventure/Coordinators/RootCoordinator.swift
+++ b/Pokemon Tabletop Adventure/Coordinators/RootCoordinator.swift
@@ -1,0 +1,36 @@
+//
+//  RootCoordinator.swift
+//  PTA Companion
+//
+//  Created by Ian Merryweather on 10/06/2021.
+//  Copyright © 2021 Undersea Love. All rights reserved.
+//
+
+import UIKit
+
+class RootCoordinator: Coordinator {
+    var childCoordinators: [Coordinator] = []
+    var router: UINavigationController
+    
+    init(router: UINavigationController) {
+        self.router = router
+    }
+    
+    func start() {
+        launch(rootViewController)
+    }
+}
+
+private extension RootCoordinator {
+    func launch(_ viewController: UIViewController) {
+        if router.viewControllers.contains(viewController) {
+            router.popToViewController(viewController, animated: true)
+        } else {
+            router.pushViewController(viewController, animated: true)
+        }
+    }
+    
+    var rootViewController: RootViewController {
+        RootViewController()
+    }
+}

--- a/Pokemon Tabletop Adventure/Coordinators/RootCoordinator.swift
+++ b/Pokemon Tabletop Adventure/Coordinators/RootCoordinator.swift
@@ -17,7 +17,17 @@ class RootCoordinator: Coordinator {
     }
     
     func start() {
-        launch(rootViewController)
+        router.setNavigationBarHidden(true, animated: false)
+        launch(preliminaryLoadingViewController)
+    }
+}
+
+extension RootCoordinator: ActionDelegate {
+    func respondToAction(_ action: Action) {
+        switch action {
+        case .preliminaryLoadingCompleted:
+            preliminaryLoadingCompleted()
+        }
     }
 }
 
@@ -28,6 +38,18 @@ private extension RootCoordinator {
         } else {
             router.pushViewController(viewController, animated: true)
         }
+    }
+    
+    func preliminaryLoadingCompleted() {
+        print("PRELIMINARY LOADING COMPLETED! YEY!")
+    }
+    
+    var preliminaryLoadingViewController: PreliminaryLoadingViewController {
+        let viewModel = PreliminaryLoadingViewModel(actionDelegate: self)
+        let controller = PreliminaryLoadingViewController(loadable: viewModel)
+        controller.actionDelegate = self
+        
+        return controller
     }
     
     var rootViewController: RootViewController {

--- a/Pokemon Tabletop Adventure/Coordinators/RootCoordinator.swift
+++ b/Pokemon Tabletop Adventure/Coordinators/RootCoordinator.swift
@@ -8,16 +8,16 @@
 
 import UIKit
 
-class RootCoordinator: Coordinator {
+final class RootCoordinator: Coordinator {
     var childCoordinators: [Coordinator] = []
     var router: UINavigationController
     
     init(router: UINavigationController) {
+        router.setNavigationBarHidden(true, animated: false)
         self.router = router
     }
     
     func start() {
-        router.setNavigationBarHidden(true, animated: false)
         launch(preliminaryLoadingViewController)
     }
 }
@@ -32,16 +32,8 @@ extension RootCoordinator: ActionDelegate {
 }
 
 private extension RootCoordinator {
-    func launch(_ viewController: UIViewController) {
-        if router.viewControllers.contains(viewController) {
-            router.popToViewController(viewController, animated: true)
-        } else {
-            router.pushViewController(viewController, animated: true)
-        }
-    }
-    
     func preliminaryLoadingCompleted() {
-        print("PRELIMINARY LOADING COMPLETED! YEY!")
+        router.crossDissolveViewController(tabBarController, replaceOldViewControllers: true)
     }
     
     var preliminaryLoadingViewController: PreliminaryLoadingViewController {
@@ -52,7 +44,7 @@ private extension RootCoordinator {
         return controller
     }
     
-    var rootViewController: RootViewController {
-        RootViewController()
+    var tabBarController: TabBarController {
+        TabBarController()
     }
 }

--- a/Pokemon Tabletop Adventure/Utilities/ActionDelegate.swift
+++ b/Pokemon Tabletop Adventure/Utilities/ActionDelegate.swift
@@ -1,0 +1,17 @@
+//
+//  ActionDelegate.swift
+//  PTA Companion
+//
+//  Created by Ian Merryweather on 10/06/2021.
+//  Copyright © 2021 Undersea Love. All rights reserved.
+//
+
+import Foundation
+
+protocol ActionDelegate: class {
+    func respondToAction(_ action: Action)
+}
+
+enum Action {
+    case preliminaryLoadingCompleted
+}

--- a/Pokemon Tabletop Adventure/Utilities/AppDelegate.swift
+++ b/Pokemon Tabletop Adventure/Utilities/AppDelegate.swift
@@ -23,7 +23,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         window?.makeKeyAndVisible()
         
         let navigationController = UINavigationController()
-        navigationController.setNavigationBarHidden(true, animated: false)
         window?.rootViewController = navigationController
         
         rootCoordinator = RootCoordinator(router: navigationController)

--- a/Pokemon Tabletop Adventure/Utilities/AppDelegate.swift
+++ b/Pokemon Tabletop Adventure/Utilities/AppDelegate.swift
@@ -12,27 +12,24 @@ import UIKit
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
-    // swiftlint:disable force_cast force_unwrapping
+    // swiftlint:disable:next force_cast
     static var shared: AppDelegate { return UIApplication.shared.delegate as! AppDelegate }
-    var root: RootViewController { return window!.rootViewController as! RootViewController }
-    // swiftlint:enable force_cast force_unwrap
 
+    var rootCoordinator: RootCoordinator?
     var window: UIWindow?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions options: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         window = UIWindow(frame: UIScreen.main.bounds)
         window?.makeKeyAndVisible()
-
-        // MARK: Legacy
-//        let rootViewController = TabBarController()
-//        window?.rootViewController = rootViewController
-
-        // MARK: New
-        let rootController = RootViewController()
-        window?.rootViewController = rootController
-
+        
+        let navigationController = UINavigationController()
+        navigationController.setNavigationBarHidden(true, animated: false)
+        window?.rootViewController = navigationController
+        
+        rootCoordinator = RootCoordinator(router: navigationController)
         setAppearances()
 
+        rootCoordinator?.start()
         return true
     }
 
@@ -50,79 +47,4 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         allNavigationBars.titleTextAttributes = attributes
         allNavigationBars.largeTitleTextAttributes = attributes
     }
-
-    func applicationWillResignActive(_ application: UIApplication) {
-        // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary
-        // interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition
-        // to the background state. Use this method to pause ongoing tasks, disable timers, and invalidate graphics rendering callbacks.
-        // Games should use this method to pause the game.
-    }
-
-    func applicationDidEnterBackground(_ application: UIApplication) {
-        // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to
-        // restore your application to its current state in case it is terminated later.
-        // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits
-    }
-
-    func applicationWillEnterForeground(_ application: UIApplication) {
-        // Called as part of the transition from the background to the active state;
-        // here you can undo many of the changes made on entering the background.
-    }
-
-    func applicationDidBecomeActive(_ application: UIApplication) {
-        // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in
-        // the background, optionally refresh the user interface.
-    }
-
-    func applicationWillTerminate(_ application: UIApplication) {
-        // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
-        // Saves changes in the application's managed object context before the application terminates.
-        self.saveContext()
-    }
-
-    // MARK: - Core Data stack
-
-    lazy var persistentContainer: NSPersistentContainer = {
-        /* The persistent container for the application. This implementation
-         creates and returns a container, having loaded the store for the
-         application to it. This property is optional since there are legitimate
-         error conditions that could cause the creation of the store to fail. */
-        let container = NSPersistentContainer(name: "Pokemon_Tabletop_Adventure")
-        container.loadPersistentStores { storeDescription, error in
-            if let error = error as NSError? {
-                // Replace this implementation with code to handle the error appropriately.
-                // fatalError() causes the application to generate a crash log and terminate. You should not use this function in a shipping
-                // application, although it may be useful during development.
-                 
-                /* Typical reasons for an error here include:
-                 * The parent directory does not exist, cannot be created, or disallows writing.
-                 * The persistent store is not accessible, due to permissions or data protection when the device is locked.
-                 * The device is out of space.
-                 * The store could not be migrated to the current model version.
-                 Check the error message to determine what the actual problem was. */
-                fatalError("Unresolved error \(error), \(error.userInfo)")
-            }
-
-            print("Store description: \(storeDescription)")
-        }
-        return container
-    }()
-
-    // MARK: - Core Data Saving support
-
-    func saveContext () {
-        let context = persistentContainer.viewContext
-        if context.hasChanges {
-            do {
-                try context.save()
-            } catch {
-                // Replace this implementation with code to handle the error appropriately.
-                // fatalError() causes the application to generate a crash log and terminate. You should not use this function in a shipping
-                // application, although it may be useful during development.
-                let nserror = error as NSError
-                fatalError("Unresolved error \(nserror), \(nserror.userInfo)")
-            }
-        }
-    }
-
 }

--- a/Pokemon Tabletop Adventure/Utilities/Extensions.swift
+++ b/Pokemon Tabletop Adventure/Utilities/Extensions.swift
@@ -157,6 +157,31 @@ public extension UILabel {
     }
 }
 
+public extension UINavigationController {
+    /// Instructs the navigation controller to add a view controller to its stack without animation, thus preventing the built-in animations, and applies a fade layer transition using the Core
+    /// Animation Transition API for the supplied duration.
+    /// - Parameters:
+    ///   - viewController: The view controller to add to the navigation controller's view controller stack.
+    ///   - duration: The time interval the animation should stretch over. The default value is `0.3`.
+    ///   - replaceOldViewControllers: A flag that instructs the navigation controller to replace the pre-existing view controller stack with the supplied view controller.
+    ///   The default value is `false`.
+    func crossDissolveViewController(_ viewController: UIViewController,
+                                     duration: TimeInterval = 0.3,
+                                     replaceOldViewControllers shouldReplace: Bool = false) {
+        let transition: CATransition = CATransition()
+        transition.duration = 0.3
+        transition.type = CATransitionType.fade
+        navigationController?.view.layer.add(transition, forKey: nil)
+        
+        if shouldReplace {
+            setViewControllers([viewController], animated: false)
+        } else {
+            pushViewController(viewController, animated: false)
+
+        }
+    }
+}
+
 public extension UIProgressView {
     func loop() {
         (progressTintColor, trackTintColor) = (trackTintColor, progressTintColor)

--- a/Pokemon Tabletop Adventure/View Controllers/PreliminaryLoadingViewController.swift
+++ b/Pokemon Tabletop Adventure/View Controllers/PreliminaryLoadingViewController.swift
@@ -87,7 +87,7 @@ private extension PreliminaryLoadingViewController {
         timer.invalidate()
         progressIndicator.isHidden = true
         loadingWarning.isHidden = true
-        AppDelegate.shared.root.splashDidFinish()
+//        AppDelegate.shared.root.splashDidFinish()
     }
 }
 

--- a/Pokemon Tabletop Adventure/View Controllers/PreliminaryLoadingViewController.swift
+++ b/Pokemon Tabletop Adventure/View Controllers/PreliminaryLoadingViewController.swift
@@ -9,20 +9,19 @@
 import UIKit
 
 class PreliminaryLoadingViewController: UIViewController {
+    required init?(coder aDecoder: NSCoder) { fatalError("No storyboards!") }
 
-    private let appLogo: UIImageView
-    private let loadingWarning: UILabel
-    private let progressIndicator: UIProgressView
+    weak var actionDelegate: ActionDelegate?
+    
+    private let appLogo = UIImageView(frame: .zero)
+    private let loadingWarning = UILabel(frame: .zero)
+    private let progressIndicator = UIProgressView(progressViewStyle: .default)
+    private let viewModel: PreliminaryLoadable
 
-    init() {
-        appLogo = UIImageView(frame: .zero)
-        loadingWarning = UILabel(frame: .zero)
-        progressIndicator = UIProgressView(progressViewStyle: .default)
-
+    init(loadable viewModel: PreliminaryLoadable) {
+        self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
     }
-
-    required init?(coder aDecoder: NSCoder) { return nil }
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -87,7 +86,7 @@ private extension PreliminaryLoadingViewController {
         timer.invalidate()
         progressIndicator.isHidden = true
         loadingWarning.isHidden = true
-//        AppDelegate.shared.root.splashDidFinish()
+        actionDelegate?.respondToAction(.preliminaryLoadingCompleted)
     }
 }
 

--- a/Pokemon Tabletop Adventure/View Controllers/RootViewController.swift
+++ b/Pokemon Tabletop Adventure/View Controllers/RootViewController.swift
@@ -13,11 +13,11 @@ class RootViewController: UIViewController {
         fatalError("Please check your implementation, \(#function) should not be called.")
     }
 
-    var currentContext: UIViewController
+//    var currentContext: UIViewController
     var contexts: [UIViewController]
 
     init() {
-        currentContext = PreliminaryLoadingViewController()
+//        currentContext = PreliminaryLoadingViewController()
         contexts = []
 
         super.init(nibName: nil, bundle: nil)
@@ -26,11 +26,11 @@ class RootViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        addChild(currentContext)
-        view.addSubview(currentContext.view)
+//        addChild(currentContext)
+//        view.addSubview(currentContext.view)
 
         updateAppearance()
-        currentContext.willMove(toParent: self)
+//        currentContext.willMove(toParent: self)
     }
 
     private func updateAppearance() {
@@ -40,18 +40,18 @@ class RootViewController: UIViewController {
     }
 
     func splashDidFinish() {
-        let target = TabBarController()
-        contexts = [target]
-
-        let animationOptions: UIView.AnimationOptions = [.curveEaseOut, .transitionCrossDissolve]
-        currentContext.willMove(toParent: nil)
-        addChild(target)
-        transition(from: currentContext, to: target, duration: 0.3, options: animationOptions, animations: nil) { [weak self] completed in
-            guard completed, let self = self else { return }
-
-            self.currentContext.removeFromParent()
-            self.currentContext = target
-            target.didMove(toParent: self)
-        }
+//        let target = TabBarController()
+//        contexts = [target]
+//
+//        let animationOptions: UIView.AnimationOptions = [.curveEaseOut, .transitionCrossDissolve]
+//        currentContext.willMove(toParent: nil)
+//        addChild(target)
+//        transition(from: currentContext, to: target, duration: 0.3, options: animationOptions, animations: nil) { [weak self] completed in
+//            guard completed, let self = self else { return }
+//
+//            self.currentContext.removeFromParent()
+//            self.currentContext = target
+//            target.didMove(toParent: self)
+//        }
     }
 }

--- a/Pokemon Tabletop Adventure/View Models/PreliminaryLoadingViewModel.swift
+++ b/Pokemon Tabletop Adventure/View Models/PreliminaryLoadingViewModel.swift
@@ -1,0 +1,38 @@
+//
+//  PreliminaryLoadingViewModel.swift
+//  PTA Companion
+//
+//  Created by pool on 10/06/2021.
+//  Copyright © 2021 Undersea Love. All rights reserved.
+//
+
+import Foundation
+
+final class PreliminaryLoadingViewModel: PreliminaryLoadable {
+    private weak var actionDelegate: ActionDelegate?
+    
+    init(actionDelegate: ActionDelegate?) {
+        self.actionDelegate = actionDelegate
+    }
+    
+    func bind(_ inputs: PreliminaryLoadableInputs) -> PreliminaryLoadableOutputs {
+        return .init()
+    }
+    
+    func loadInitialData() {
+        
+    }
+}
+
+protocol PreliminaryLoadable {
+    func bind(_ inputs: PreliminaryLoadableInputs) -> PreliminaryLoadableOutputs
+    func loadInitialData()
+}
+
+struct PreliminaryLoadableInputs {
+    
+}
+
+struct PreliminaryLoadableOutputs {
+    
+}


### PR DESCRIPTION
### Proposed Changes

Removes the old `RootViewController` from the app start-up flow, and manages the initial loading and presentation o the tab bar via a Coordinator object.

Adds some progress to #30 

- Introduces the `Coordinator` protocol to allow a move towards MVVMC responsibilities.
- Introduces the `ActionDelegate` protocol to allow loosely-coupled interaction between view controllers and navigation handlers without bloating the codebase with many different view controller delegates
- Injects a view model to the `PreliminaryLoadingViewController` as a forward-base for handling a deeper refactor
