### PR TITLE
feat: Encoding moves from name only

### DIFF
--- a/Pokemon Tabletop Adventure/Data Models/Pokemon.swift
+++ b/Pokemon Tabletop Adventure/Data Models/Pokemon.swift
@@ -58,9 +58,9 @@ struct Biology: Codable {
 struct Contest: Codable {
     enum Category: String, Codable {
         case beauty = "Beauty"
+        case clever = "Clever"
         case cool = "Cool"
         case cute = "Cute"
-        case smart = "Smart"
         case tough = "Tough"
     }
     
@@ -85,6 +85,8 @@ struct Passives: Codable {
 }
 
 struct PokeMove: Codable {
+    static var cachedMoves: [PokeMove]?
+    
     enum Category: String, Codable {
         case attack = "Attack"
         case effect = "Effect"
@@ -148,7 +150,10 @@ enum Environment: String, Codable {
 }
 
 enum PokeType: String, Codable {
+    case bug = "Bug"
     case dark = "Dark"
+    case dragon = "Dragon"
+    case electric = "Electric"
     case fairy = "Fairy"
     case fire = "Fire"
     case fighting = "Fighting"
@@ -156,9 +161,13 @@ enum PokeType: String, Codable {
     case ghost = "Ghost"
     case grass = "Grass"
     case ground = "Ground"
+    case ice = "Ice"
+    case normal = "Normal"
     case poison = "Poison"
     case psychic = "Psychic"
+    case rock = "Rock"
     case steel = "Steel"
+    case typeless = "Typeless"
     case water = "Water"
 }
 

--- a/Pokemon Tabletop Adventure/Data Models/Pokemon.swift
+++ b/Pokemon Tabletop Adventure/Data Models/Pokemon.swift
@@ -17,7 +17,7 @@ struct Pokedex: Codable {
 struct Pokemon: Codable, Equatable {
     let biology: Biology
     let evolution: [Evolution]
-    let moves: [String]             // Convert to PokeMove
+    let moves: [PokeMove]
     let name: String
     let passives: Passives
     let proficiencies: Proficiency
@@ -45,6 +45,28 @@ struct Pokemon: Codable, Equatable {
     static func == (lhs: Pokemon, rhs: Pokemon) -> Bool {
         let areEqual = lhs.ptaID == rhs.ptaID
         return areEqual
+    }
+    
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.biology = try container.decode(Biology.self, forKey: .biology)
+        self.evolution = try container.decode([Evolution].self, forKey: .evolution)
+        self.name = try container.decode(String.self, forKey: .name)
+        self.passives = try container.decode(Passives.self, forKey: .passives)
+        self.proficiencies = try container.decode(Proficiency.self, forKey: .proficiencies)
+        self.ptaID = try container.decode(Int.self, forKey: .ptaID)
+        self.ptaPage = try container.decode(String.self, forKey: .ptaPage)
+        self.size = try container.decode(SizeClass.self, forKey: .size)
+        self.skills = try container.decode([String].self, forKey: .skills)
+        self.stats = try container.decode(Stats.self, forKey: .stats)
+        self.type = try container.decode([PokeType].self, forKey: .type)
+        self.weight = try container.decode(WeightClass.self, forKey: .weight)
+        
+        let moveNames = try container.decode([String].self, forKey: .moves)
+        let moves = PokeMove.cachedMoves ?? [].filter { move in
+            moveNames.contains(move.name)
+        }
+        self.moves = moves
     }
 }
 

--- a/Pokemon Tabletop Adventure/Data Models/Pokemon.swift
+++ b/Pokemon Tabletop Adventure/Data Models/Pokemon.swift
@@ -39,6 +39,10 @@ struct Pokemon: Codable, Equatable {
             SPA: \(stats.specialAttack)
             SDF: \(stats.specialDefence)
             SPD: \(stats.speed)
+        Moves:
+            \(moves.isEmpty ? "" : "• \(moves[0].description)")
+            \(moves.count > 1 ? "• \(moves[1].description)" : "")
+            \(moves.count > 2 ? "• \(moves[2].description)" : "")
         """
     }
     
@@ -131,6 +135,12 @@ struct PokeMove: Codable {
     let name: String
     let range: String
     let type: PokeType
+    
+    var description: String {
+        var descriptionText = "\(name): \(range) \(type.rawValue) \(category.rawValue): \(frequency.rawValue)"
+        descriptionText.append(" \(damageAmount > 0 ? "\(damageAmount)d\(damageDie)" : "")\(effect.isEmpty ? "" : "\n\(effect)")")
+        return descriptionText
+    }
 }
 
 struct PokeSkill: Codable {

--- a/Pokemon Tabletop Adventure/Data Models/Pokemon.swift
+++ b/Pokemon Tabletop Adventure/Data Models/Pokemon.swift
@@ -9,6 +9,7 @@
 import Foundation
 
 struct Pokedex: Codable {
+    static var cachedPokedex: Pokedex?
     static var empty = Self(pokemon: [])
     let pokemon: [Pokemon]
 }

--- a/Pokemon Tabletop Adventure/Utilities/JSON.swift
+++ b/Pokemon Tabletop Adventure/Utilities/JSON.swift
@@ -41,6 +41,20 @@ enum JSON {
         }
     }
     
+    private static func cachePokeMoves() {
+        let filename = "moves"
+        let jsonDecoder = JSONDecoder()
+        
+        do {
+            let movesJSON = try getJSON(from: filename)
+            let decoded = try jsonDecoder.decode([String: [PokeMove]].self, from: movesJSON)
+            guard let moves = decoded["moves"] else { throw JSONError.incorrectDataFormat(filename: "\(filename).json") }
+            PokeMove.cachedMoves = moves
+        } catch {
+            logJsonFailure(error, for: filename)
+        }
+    }
+    
     private static func logJsonFailure(_ error: Error, for filename: String, in function: String = #function) {
         var description: String
         switch error as? DecodingError {
@@ -54,6 +68,7 @@ enum JSON {
     }
 
     static func setupDataCache(completion: @escaping () -> Void) {
+        cachePokeMoves()
         cachePokedex()
         DispatchQueue.main.async { completion() }
     }
@@ -76,6 +91,6 @@ enum JSON {
     private enum JSONError: Error {
         case dataFileReadError(filename: String)
         case fileNotFound(filename: String)
-        case pokedexFormatWrong
+        case incorrectDataFormat(filename: String)
     }
 }

--- a/Pokemon Tabletop Adventure/View Controllers/PreliminaryLoadingViewController.swift
+++ b/Pokemon Tabletop Adventure/View Controllers/PreliminaryLoadingViewController.swift
@@ -52,7 +52,7 @@ private extension PreliminaryLoadingViewController {
         let main = DispatchQueue.main
         jsonQueue.async {
             Thread.sleep(forTimeInterval: 0.5)
-            JSON.setupPokedexCache { [weak self] in
+            JSON.setupDataCache { [weak self] in
                 guard let self = self else { return }
                 self.loadingWarning.updateAttributedText(LoadingMessage.valueAnalysingPokedex)
 

--- a/Pokemon Tabletop Adventure/View Controllers/RandomPokemonViewController.swift
+++ b/Pokemon Tabletop Adventure/View Controllers/RandomPokemonViewController.swift
@@ -51,9 +51,9 @@ class RandomPokemonViewController: BaseViewController {
         
         view.addSubview(descriptionLabel)
         NSLayoutConstraint.activate([
-            descriptionLabel.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 50),
-            descriptionLabel.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 50),
-            descriptionLabel.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: 50)]
+            descriptionLabel.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 24),
+            descriptionLabel.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 16),
+            descriptionLabel.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -16)]
         )
     }
     


### PR DESCRIPTION
- Moves pokedex cache into pokedex data struct 
  - Encapsulates json loading into separate function to enable easier logging and access to other data files
- Adds caching for pokemon moves 
  - Updates the pokemon move contest categories enum
  - Updates the pokemon type enum to have all values
- Decodes moves based on name provided in pokedex json 
  - Interprets the list of cached pokemon moves to retrieve the full pokemon move data instead of requiring it in the pokedex json
- Adds moves to basic pokemon description 
  - Adds a description for pokemon moves to mirror the presentation in the PTA3 rulebooks